### PR TITLE
修改重建图片列表预览问题

### DIFF
--- a/dist/viewer.js
+++ b/dist/viewer.js
@@ -388,8 +388,11 @@
     if (!value) {
       return;
     }
+    if(!element){
+    	return;
+    }
 
-    if (isNumber(element.length)) {
+    if (typeof(element.length)!='undefined' && isNumber(element.length)) {
       forEach(element, function (elem) {
         removeClass(elem, value);
       });
@@ -1659,7 +1662,9 @@
       var index = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 0;
 
       index = Number(index) || 0;
-
+      
+      index = index >= this.length?0:index;
+      
       if (!this.isShown) {
         this.index = index;
         return this.show();


### PR DESCRIPTION
当在原来的图片列表选中一个序号较大的图片后,重建图片列表的长度比该序号小,下次的viewer.show()无法预览图片

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [guidelines](https://github.com/fengyuanchen/viewer/blob/master/.github/CONTRIBUTING.md#commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update
[ ] Refactor
[ ] Build related changes
[ ] Documentation content changes
[ ] Other, Please describe:
```


## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
